### PR TITLE
Fix compiling errors

### DIFF
--- a/examples/umyo_IMU/umyo_IMU.ino
+++ b/examples/umyo_IMU/umyo_IMU.ino
@@ -18,6 +18,8 @@ void setup() {
   uMyo.begin(rf_cs, rf_cen);
 }
 
+uint32_t last_print_ms = 0;
+
 void loop() 
 {
   uMyo.run(); //need to call this really often, therefore

--- a/src/uMyo_RF24.h
+++ b/src/uMyo_RF24.h
@@ -55,8 +55,6 @@ private:
 	int device_count;
 	uint8_t idToIdx(uint32_t id);
 	uint8_t swapbits(uint8_t a);
-	float asin_f(float x);
-	float atan2_f(float y, float x);
 public:
 	uMyo_RF24_(void);
 	void begin(int pin_cs, int pin_ce);


### PR DESCRIPTION
### fixing a few compiling errors

in file `umyo_IMU.ino`:
 i add the missed definition for `last_print_ms` variable

in file `uMyo_RF24.h`:
 i remove the `atan2_f` and `asin_f` functions definition that are not implemented in this class (these functions are already define and implemented in `quat_math.h` so we don't need them here)

