### PR TITLE
Add support for NRF52840

### DIFF
--- a/examples/umyo_basic_NRF52/umyo_basic_NRF52.ino
+++ b/examples/umyo_basic_NRF52/umyo_basic_NRF52.ino
@@ -1,0 +1,36 @@
+/*
+Obtaining muscle data from uMyo via nRF24 module
+Usage: attach nRF24 module using any tutorial
+ - open Serial Plotter (or Serial Monitor) at 115200 speed
+ - turn on uMyo device
+ - switch it into RF24 mode if necessary (to switch, 
+press button once or twice, depending on current mode until you see 3 pink blinks)
+ - you should see muscle activity chart on a plot (or as serial output)
+*/
+
+#include <uMyo_RF24.h>
+
+
+void setup() {
+  Serial.begin(115200);
+  uMyo.begin();
+}
+
+uint32_t last_print_ms = 0;
+
+void loop() 
+{
+  uMyo.run(); //need to call this really often, therefore
+  //no delays can be used in the code
+  int dev_count = uMyo.getDeviceCount(); //if more than one device is present, show all of them
+  if(millis() - last_print_ms > 30)
+  {
+    for(int d = 0; d < dev_count; d++)
+    {
+      Serial.print(uMyo.getMuscleLevel(d));
+      if(d < dev_count-1) Serial.print(' ');
+      else Serial.println();
+    }
+    last_print_ms = millis();
+  }
+}

--- a/src/uMyo_RF24.h
+++ b/src/uMyo_RF24.h
@@ -21,7 +21,13 @@
 #ifndef UMYO_RF24_h
 #define UMYO_RF24_h
 
+#if defined(ARDUINO_ARCH_NRF52) || defined(ARDUINO_ARCH_NRF52840) || defined(ARDUINO_ARCH_NRF52833)
+#define NRF52
+#include <nrf_to_nrf.h>
+#else
 #include <RF24.h>
+#endif
+
 #include "quat_math.h"
 #define MAX_UMYO_DEVICES 12
 
@@ -52,7 +58,11 @@ typedef struct uMyo_data
 class uMyo_RF24_
 {
 private:
-	RF24 *rf;
+    #if defined (NRF52)
+	  nrf_to_nrf *rf;
+    #else
+      RF24 *rf;  
+    #endif
 	uMyo_data devices[MAX_UMYO_DEVICES];
 	sV nx, ny, nz;
 	int device_count;
@@ -62,6 +72,7 @@ private:
 public:
 	uMyo_RF24_(void);
 	void begin(int pin_cs, int pin_ce);
+	void begin();
 	void run();
 	void setProtocolVersion(int version);	
 	uint8_t getDeviceCount();


### PR DESCRIPTION
This library can support the new [nrf_to_nrf](https://github.com/TMRh20/nrf_to_nrf) radio driver for NRF52840 devices (XIAO BLE SENSE 52840 ) etc. 
These changes allow that.

There is also the possibility of using C++ templates to do this, instead of using #defines, but this method is simple and more straightforward.

I also added an example, which may not be needed, because the NRF52 should work with the default configuration as well.

Not sure if there is much interest, but I recently had a request from a user to support this library with nrf_to_nrf
